### PR TITLE
fix: nav links text

### DIFF
--- a/src/data/components/header.json
+++ b/src/data/components/header.json
@@ -5,11 +5,11 @@
       "to": "/"
     },
     {
-      "title": "Curriculum",
+      "title": "Curriculum Overview",
       "to": "/curriculum"
     },
     {
-      "title": "Culture",
+      "title": "Cultural Activities",
       "to": "/culture"
     },
     {


### PR DESCRIPTION
### Updates our navigation routes:

`Culture` > `Cultural Activities`
`Curriculum` > ` Curriculum Overview`

Thoughts?


#### Related issues
https://github.com/colindamelio/saraswati/issues/1