### PR TITLE
fix: CTA text-wrap on mobile

### DIFF
--- a/src/components/Cta.js
+++ b/src/components/Cta.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import mq from 'utils/mq';
 
 const Cta = styled.a`
   padding: ${props => props.theme.ctaPadding};
@@ -45,6 +46,23 @@ const Cta = styled.a`
       }
     }
   }
+  ${mq.mobile`
+    width: 100%;
+    text-align: center;
+    &:nth-child(n + 2) {
+      padding: ${props => props.theme.ctaPadding};
+      margin-left: 0;
+      margin-top: 15px;
+      text-decoration: underline;
+    }
+    &.secondary {
+      &:nth-child(n + 2) {
+        padding: ${props => props.theme.ctaPadding};
+        margin-left: 0;
+        margin-top: 15px;
+        text-decoration: underline;
+      }
+  `};
 `;
 
 export default Cta;

--- a/src/components/Tout.js
+++ b/src/components/Tout.js
@@ -19,6 +19,7 @@ const CtaContainer = styled.div`
     margin-top: ${props => props.theme.paddingTablet};
   `} ${mq.mobile`
     margin-top: ${props => props.theme.paddingMobile};
+    flex-direction: column;
   `};
 `;
 


### PR DESCRIPTION
Change `CTA` width to `100%` on `Mobile` to prevent wrapping.
Also introduce `text-decoration: underline` so it's obvious that text is clickable.

**Related Issues**
https://github.com/colindamelio/saraswati/issues/29

**Visual References**
![screen shot 2018-09-14 at 5 33 30 pm](https://user-images.githubusercontent.com/3442525/45576227-56e5fc80-b844-11e8-83c1-dc8d5bdb9c8c.png)
