### PR TITLE
fix: Images stretching vertically (IE)

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,9 +1,9 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 const Image = styled.img`
   display: block;
   width: 100%;
-  max-width: ${props => `${props.width}px`};
+  flex-shrink: 0;
 `;
 
 export default Image;


### PR DESCRIPTION
Introduce `flex-shrink: 0` on `img` to correct vertical stretching in `IE` (random).

**Related Issues:**
https://github.com/colindamelio/saraswati/issues/34

**Visual References**
![screen shot 2018-09-14 at 7 02 01 pm](https://user-images.githubusercontent.com/3442525/45578680-07f29400-b851-11e8-87d6-a5e7177b168b.png)
