### PR TITLE
fix: 2-column hero content stretching (IE)

### DIFF
--- a/src/components/H1.js
+++ b/src/components/H1.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import mq from 'utils/mq';
 
 const H1 = styled.h1`
+  width: 100%;
   font-family: ${props => props.theme.primaryFont};
   font-weight: ${props => props.theme.light};
   font-size: ${props => props.theme.heroTitleDesktop};

--- a/src/components/H2.js
+++ b/src/components/H2.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import mq from 'utils/mq';
 
 const H2 = styled.h2`
+  width: 100%;
   font-family: ${props => props.theme.primaryFont};
   font-weight: ${props => props.theme.bold};
   font-size: ${props => props.theme.subtitleDesktop};

--- a/src/components/Tout.js
+++ b/src/components/Tout.js
@@ -9,6 +9,7 @@ import mq from '../utils/mq';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
 `;
 
 const CtaContainer = styled.div`


### PR DESCRIPTION
Width is _explicitly_ defined at `100%` (because IE is stupid)

**Related Issues**
https://github.com/colindamelio/saraswati/issues/33

**Visual References**
![screen shot 2018-09-14 at 7 11 16 pm](https://user-images.githubusercontent.com/3442525/45578906-3cb31b00-b852-11e8-9591-f0c83532e91b.png)
