### PR TITLE
Switch to HashRouter

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { HashRouter, Route, Switch } from 'react-router-dom';
 import ScrollToTop from './ScrollToTop';
 import Home from 'routes/Home';
 import Curriculum from 'routes/Curriculum';
@@ -11,7 +11,7 @@ import Footer from 'modules/Footer';
 
 const Body = props => {
   return (
-    <BrowserRouter>
+    <HashRouter>
       <Fragment>
         <Header isDesktop={props.isDesktop} />
         <ScrollToTop>
@@ -38,7 +38,7 @@ const Body = props => {
         </ScrollToTop>
         <Footer />
       </Fragment>
-    </BrowserRouter>
+    </HashRouter>
   );
 };
 


### PR DESCRIPTION
Fixes https://github.com/colindamelio/saraswati/issues/40.

`BrowserRouter()` will work fine locally, but is prone to errors on the server (this means you will not experience any bugs locally, only in Production). `HashRouter()` is the solution to this problem, as explained [here](https://stackoverflow.com/a/51975988):

> **SERVER SIDE:** HashRouter uses a hash symbol in the URL, which has the effect of all subsequent URL path content being ignored in the server request (ie you send "www.mywebsite.com/#/person/john" the server gets "www.mywebsite.com". As a result the server will return the pre # URL response, and then the post # path will be handled by parsed by your client side react application.
>
> **CLIENT SIDE:** BrowserRouter will not append the # symbol to your URL, however will create issues when you try to link to a page or reload a page. If the explicit route exists in your client react app, but not on your server, reloading and linking(anything that hits the server directly) will return 404 not found errors.