### PR TITLE
fix: Replace Wood Image (landing)

### DIFF
--- a/src/modules/curriculum/CourseStructure.js
+++ b/src/modules/curriculum/CourseStructure.js
@@ -4,9 +4,8 @@ import styled from 'styled-components';
 import mq from 'utils/mq';
 import Touts from 'components/Touts';
 import H1 from 'components/H1';
-import H2 from 'components/H2';
 import Tout from 'components/Tout';
-import HeroImage from '../../media/wood-texture-1.jpg';
+import HeroImage from 'media/wood-texture-1.jpg';
 
 const Column = styled.div`
   width: 100%;

--- a/src/modules/home/CultureOnly.js
+++ b/src/modules/home/CultureOnly.js
@@ -5,7 +5,7 @@ import mq from 'utils/mq';
 import Hero from 'components/Hero';
 import H2 from 'components/H2';
 import Tout from 'components/Tout';
-import HeroImage from 'media/wood-texture-3.jpg';
+import HeroImage from 'media/wood-texture-1.jpg';
 
 const Column = styled.div`
   width: 100%;


### PR DESCRIPTION
Replace image on landing page and removed unused `H2`